### PR TITLE
Improve core backend code greatly

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,8 +8,7 @@ app.debug = True
 
 def fizz_buzz(num):
     # This is a single line, so it's an atomic operation.
-    return list(map(lambda x: "FizzBuzz" if x % 3 == 0 and x % 5 == 0
-                    else ("Fizz" if x % 3 == 0 else("Buzz" if x % 5 == 0 else x)), range(1, num + 1)))
+    return ["FizzBuzz"[i*i%3*4:8--i**4%5] or i for i in range(1, num + 1)]
 
 @app.route("/")
 def index():


### PR DESCRIPTION
I'm going to attempt to partially explain what this one-liner is
doing. Basically, the lowest precedences operators here are the ':'
slice and the 'or i' part. Remember that the empty list is considered
falsy in Python, so if the slice into "FizzBuzz" returns the empty list,
i will be substituted instead. (This is the first major piece of the
puzzle.) The other thing is that, if i is divisible by just 3,
"FizzBuzz"[0:4](just) will be sliced, if i is divisible by just
5, "FizzBuzz"[4:8](just) will be sliced, and if i is divisible
by both 3 and 5, "FizzBuzz"[0:8](the whole string) will be sliced.

So the first part of the slice. Recall that, if i is not divisible by
some n, i to any power is also not divisible by that n. Furthermore, by
some accident of number theory, i*i%3 is always 0 or 1. The result is
then multiplied by four, ultimately resulting in the first part of the
slice being 0 if i is divisible by 3, and 4 otherwise.

Now the second part of the slice. Due to operator precedence, 8--i**4%5
is actually shorthand for 8 - ((-i**4)%5). Again, by some accident of
number theory and the behavior of modulo on negative numbers in Python,
the right part is 0 when i is divisible by 5, and 4
otherwise. Interestingly, any positive integer n for which n % 5 = 1
also has (-n) % 5 = 4.

Consider also the following results:

> > > for i in range(1, num + 1):
> > > ...    print(i_i%3_4, 8--i**4%5, "FizzBuzz"[i_i%3_4:8--i**4%5])
> > > ...
> > > 4 4
> > > 4 4
> > > 0 4 Fizz
> > > 4 4
> > > 4 8 Buzz
> > > 0 4 Fizz
> > > 4 4
> > > 4 4
> > > 0 4 Fizz
> > > 4 8 Buzz
> > > 4 4
> > > 0 4 Fizz
> > > 4 4
> > > 4 4
> > > 0 8 FizzBuzz

This commit also switches to Python's list comprehension syntax. The map
builtin is actually hated by Guido Van Rossum, see
http://www.artima.com/weblogs/viewpost.jsp?thread=98196

Also see the following:
http://www.mathcs.emory.edu/~valerie/courses/fall10/155/resources/op_precedence.html
http://www.commandlinefu.com/commands/view/9454/fizzbuzz-one-liner-in-python
